### PR TITLE
Use AFL's deferred fork server

### DIFF
--- a/src/bin/sim-fuzzer.rs
+++ b/src/bin/sim-fuzzer.rs
@@ -317,6 +317,7 @@ fn fuzz(
                 .parse_afl_cmdline(arguments)
                 .coverage_map_size(MAP_SIZE)
                 .is_persistent(false)
+                .is_deferred_frksrv(true)
                 .build_dynamic_map(edges_observer, tuple_list!(time_observer))
                 .unwrap();
 


### PR DESCRIPTION
See here: https://docs.rs/libafl/latest/libafl/executors/forkserver/struct.ForkserverExecutorBuilder.html#method.is_deferred_frksrv

If we don't call is_deferred_frksrv, LibAFL++ will start the binary from scratch each time, instead of starting at __AFL_INIT().