### PR TITLE
Libafl 0.15.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ hashbrown = "0.13.2"
 #libafl = { version = "0.10.0", features = ["fork", "errors_backtrace"] }
 libm = "0.2.7"
 log = "0.4.17"
-nix = "0.26.2"
+nix = "0.29"
 num-traits = "0.2.15"
 postcard = "1.0.4"
 rand = "0.8.5"
 serde = "1.0.163"
 tui = "0.19.0"
 
-libafl = { path = "LibAFL/libafl", features = ["fork", "errors_backtrace"] }
+libafl = { path = "LibAFL/libafl", features = ["fork", "errors_backtrace", "prelude"] }
+libafl_bolts = { path = "LibAFL/libafl_bolts" }

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -15,8 +15,8 @@ pub fn assemble_instructions(input: &Vec<Instruction>) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use libafl::prelude::Rand;
-    use libafl::prelude::Xoshiro256StarRand;
+    use libafl_bolts::prelude::Rand;
+    use libafl_bolts::prelude::Xoshiro256StarRand;
 
     use crate::generator::InstGenerator;
     use crate::instructions;
@@ -66,7 +66,7 @@ mod tests {
 
             let mut insts = Vec::<Instruction>::new();
 
-            for _ in 0..rng.below(5) {
+            for _ in 0..rng.below(nonzero!(5)) {
                 let inst = generator.generate_instruction::<Xoshiro256StarRand>(
                     &mut rng,
                     &instructions::sets::riscv_g(),

--- a/src/bin/sim-fuzzer.rs
+++ b/src/bin/sim-fuzzer.rs
@@ -329,6 +329,7 @@ fn fuzz(
                 .is_deferred_frksrv(true)
                 .timeout(timeout)
                 .kill_signal(signal)
+                .min_input_size(4)
                 .target_bytes_converter(NopTargetBytesConverter::<ProgramInput>::new())
                 .build_dynamic_map(edges_observer, tuple_list!(time_observer))
                 .unwrap();

--- a/src/bin/sim-fuzzer.rs
+++ b/src/bin/sim-fuzzer.rs
@@ -54,7 +54,7 @@ use riscv_mutator::{
         Argument, Instruction,
     },
     monitor::HWFuzzMonitor,
-    mutator::{all_riscv_mutations},
+    mutator::{RiscvScheduledMutator, all_riscv_mutations},
     program_input::ProgramInput,
 };
 
@@ -307,7 +307,7 @@ fn fuzz(
             )
             .unwrap();
 
-            let mutator = StdScheduledMutator::new(all_riscv_mutations());
+            let mutator = RiscvScheduledMutator::new(all_riscv_mutations());
 
             let power = StdPowerMutationalStage::new(mutator);
 

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -1,37 +1,38 @@
-extern crate alloc;
-use alloc::string::{String, ToString};
 use core::{fmt::Debug, marker::PhantomData, time::Duration};
+use std::borrow::Cow;
 
-use hashbrown::HashSet;
-
+use std::collections::HashSet;
+use libafl_bolts::{impl_serdeany, AsIter, Named, tuples::Handle};
+use num_traits::Bounded;
 use serde::{Deserialize, Serialize};
 
 use libafl::{
-    bolts::{tuples::Named, AsIter},
-    corpus::{Corpus, CorpusId, SchedulerTestcaseMetadata},
+    corpus::{Corpus, HasCurrentCorpusId, SchedulerTestcaseMetadata},
     events::{EventFirer, LogSeverity},
     executors::{Executor, ExitKind, HasObservers},
-    feedbacks::HasObserverName,
+    feedbacks::{HasObserverHandle},
     fuzzer::Evaluator,
-    inputs::UsesInput,
-    observers::{MapObserver, ObserversTuple, UsesObserver},
+    inputs::Input,
+    observers::{MapObserver, ObserversTuple},
     schedulers::powersched::SchedulerMetadata,
-    stages::Stage,
-    state::{HasClientPerfMonitor, HasCorpus, HasMetadata, HasNamedMetadata, UsesState},
-    Error,
+    stages::{RetryCountRestartHelper, Stage},
+    state::{HasCorpus, HasCurrentTestcase, HasExecutions},
+    Error, HasMetadata, HasNamedMetadata,
 };
 
 use crate::program_input::ProgramInput;
 
-libafl::impl_serdeany!(UnstableEntriesMetadata);
+/// Default name for `CalibrationStage`; derived from AFL++
+const CALIBRATION_STAGE_NAME: &str = "calibration";
+
 /// The metadata to keep unstable entries
-/// In libafl, the stability is the number of the unstable entries divided by the size of the map
-/// This is different from AFL++, which shows the number of the unstable entries divided by the number of filled entries.
+/// Formula is same as AFL++: number of unstable entries divided by the number of filled entries.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct UnstableEntriesMetadata {
     unstable_entries: HashSet<usize>,
-    map_len: usize,
+    filled_entries_count: usize,
 }
+impl_serdeany!(UnstableEntriesMetadata);
 
 impl UnstableEntriesMetadata {
     #[must_use]
@@ -39,7 +40,7 @@ impl UnstableEntriesMetadata {
     pub fn new(entries: HashSet<usize>, map_len: usize) -> Self {
         Self {
             unstable_entries: entries,
-            map_len,
+            filled_entries_count: map_len,
         }
     }
 
@@ -51,49 +52,59 @@ impl UnstableEntriesMetadata {
 
     /// Getter
     #[must_use]
-    pub fn map_len(&self) -> usize {
-        self.map_len
+    pub fn filled_entries_count(&self) -> usize {
+        self.filled_entries_count
     }
 }
 
 /// The calibration stage will measure the average exec time and the target's stability for this input.
 #[derive(Clone, Debug)]
-pub struct DummyCalibration<O, OT, S> {
-    map_observer_name: String,
-    phantom: PhantomData<(O, OT, S)>,
+pub struct DummyCalibration<C, E, I, O, OT, S> {
+    map_observer_handle: Handle<C>,
+    map_name: Cow<'static, str>,
+    name: Cow<'static, str>,
+    phantom: PhantomData<(C, E, I, O, OT, S)>,
 }
 
-impl<O, OT, S> UsesState for DummyCalibration<O, OT, S>
-where
-    S: UsesInput,
-{
-    type State = S;
-}
+// impl<C, E, I, O, OT, S> UsesState for DummyCalibration<C, E, I, O, OT, S>
+// where
+//     S: UsesInput,
+// {
+//     type State = S;
+// }
 
-impl<E, EM, O, OT, Z> Stage<E, EM, Z> for DummyCalibration<O, OT, E::State>
+impl<C, E, EM, I, O, OT, S, Z> Stage<E, EM, S, Z> for DummyCalibration<C, E, I, O, OT, S>
 where
-    E: Executor<EM, Z> + HasObservers<Observers = OT>,
-    EM: EventFirer<State = E::State>,
+    E: Executor<EM, I, S, Z> + HasObservers<Observers = OT>,
+    EM: EventFirer<I, S>,
     O: MapObserver,
-    for<'de> <O as MapObserver>::Entry: Serialize + Deserialize<'de> + 'static,
-    OT: ObserversTuple<E::State>,
-    E::State: HasCorpus + HasMetadata + HasClientPerfMonitor + HasNamedMetadata,
-    Z: Evaluator<E, EM, State = E::State>,
-    ProgramInput: From<<<E as UsesState>::State as UsesInput>::Input>,
+    C: AsRef<O>,
+    for<'de> <O as MapObserver>::Entry:
+        Serialize + Deserialize<'de> + 'static + Default + Debug + Bounded,
+    OT: ObserversTuple<I, S>,
+    S: HasCorpus<I>
+        + HasMetadata
+        + HasNamedMetadata
+        + HasExecutions
+        + HasCurrentTestcase<I>
+        + HasCurrentCorpusId,
+    Z: Evaluator<E, EM, I, S>,
+    I: Input,
+    ProgramInput: From<I>,
 {
     fn perform(
         &mut self,
         fuzzer: &mut Z,
         executor: &mut E,
-        state: &mut E::State,
+        state: &mut S,
         mgr: &mut EM,
-        corpus_idx: CorpusId,
     ) -> Result<(), Error> {
         // Run this stage only once for each corpus entry and only if we haven't already inspected it
         {
-            let corpus = state.corpus().get(corpus_idx)?.borrow();
+            let testcase = state.current_testcase()?;
+            // println!("calibration; corpus.scheduled_count() : {}",  testcase.scheduled_count());
 
-            if corpus.scheduled_count() > 0 {
+            if testcase.scheduled_count() > 0 {
                 return Ok(());
             }
         }
@@ -101,16 +112,11 @@ where
         // We only ran our program once.
         let iter = 1;
 
-        let input = state
-            .corpus()
-            .get(corpus_idx)?
-            .borrow_mut()
-            .load_input(state.corpus())?
-            .clone();
-
+        let input = state.current_input_cloned()?;
         executor.observers_mut().pre_exec_all(state, &input)?;
 
         let exit_kind = executor.run_target(fuzzer, state, mgr, &input)?;
+
         if exit_kind != ExitKind::Ok {
             mgr.log(
                 state,
@@ -123,16 +129,15 @@ where
             .observers_mut()
             .post_exec_all(state, &input, &exit_kind)?;
 
+
         // Estimate duration based on number of instructions.
         let program: ProgramInput = input.into();
         let total_time = Duration::from_secs((program.insts().len() + 1) as u64);
 
         // If weighted scheduler or powerscheduler is used, update it
         if state.has_metadata::<SchedulerMetadata>() {
-            let map = executor
-                .observers()
-                .match_name::<O>(&self.map_observer_name)
-                .ok_or_else(|| Error::key_not_found("MapObserver not found".to_string()))?;
+            let observers = executor.observers();
+            let map = observers[&self.map_observer_handle].as_ref();
 
             let bitmap_size = map.count_bytes();
 
@@ -148,11 +153,9 @@ where
             psmeta.set_bitmap_size_log(psmeta.bitmap_size_log() + libm::log2(bitmap_size as f64));
             psmeta.set_bitmap_entries(psmeta.bitmap_entries() + 1);
 
-            let mut testcase = state.corpus().get(corpus_idx)?.borrow_mut();
-            let scheduled_count = testcase.scheduled_count();
+            let mut testcase = state.current_testcase_mut()?;
 
             testcase.set_exec_time(total_time / (iter as u32));
-            testcase.set_scheduled_count(scheduled_count + 1);
 
             // If the testcase doesn't have its own `SchedulerTestcaseMetadata`, create it.
             let data = if let Ok(metadata) = testcase.metadata_mut::<SchedulerTestcaseMetadata>() {
@@ -184,23 +187,48 @@ where
 
         Ok(())
     }
+
+    fn should_restart(&mut self, state: &mut S) -> Result<bool, Error> {
+        // Calibration stage disallow restarts
+        // If a testcase that causes crash/timeout in the queue, we need to remove it from the queue immediately.
+        RetryCountRestartHelper::no_retry(state, &self.name)
+
+        // todo
+        // remove this guy from corpus queue
+    }
+
+    fn clear_progress(&mut self, state: &mut S) -> Result<(), Error> {
+        // TODO: Make sure this is the correct way / there may be a better way?
+        RetryCountRestartHelper::clear_progress(state, &self.name)
+    }
 }
 
-impl<O, OT, S> DummyCalibration<O, OT, S>
+impl<C, E, I, O, OT, S> DummyCalibration<C, E, I, O, OT, S>
 where
+    C: AsRef<O>,
     O: MapObserver,
-    OT: ObserversTuple<S>,
-    S: HasCorpus + HasMetadata + HasNamedMetadata,
+    for<'it> O: AsIter<'it, Item = O::Entry>,
+    OT: ObserversTuple<I, S>,
 {
     #[must_use]
     pub fn new<F>(map_feedback: &F) -> Self
     where
-        F: HasObserverName + Named + UsesObserver<S, Observer = O>,
-        for<'it> O: AsIter<'it, Item = O::Entry>,
+        F: HasObserverHandle<Observer = C> + Named,
     {
+        let map_name = map_feedback.name().clone();
         Self {
-            map_observer_name: map_feedback.observer_name().to_string(),
+            map_observer_handle: map_feedback.observer_handle().clone(),
+            map_name: map_name.clone(),
             phantom: PhantomData,
+            name: Cow::Owned(
+                CALIBRATION_STAGE_NAME.to_owned() + ":" + map_name.into_owned().as_str(),
+            ),
         }
+    }
+}
+
+impl<C, E, I, O, OT, S> Named for DummyCalibration<C, E, I, O, OT, S> {
+    fn name(&self) -> &Cow<'static, str> {
+        &self.name
     }
 }

--- a/src/fuzz_ui.rs
+++ b/src/fuzz_ui.rs
@@ -3,7 +3,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use libafl::prelude::{current_time, format_duration_hms};
+use libafl_bolts::{current_time, format_duration_hms};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     io::{self, Stdout},

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -16,10 +16,12 @@ pub struct InstGenerator {
 
 impl InstGenerator {
     pub fn new() -> Self {
+        let reuse_args = !env::var("PHANTOM_TRAILS_NO_ARG_REUSE").is_ok();
+
         Self {
             known_args: Vec::<Argument>::new(),
-            reuse_chance: 50,
-            power_of_two_chance: 50,
+            reuse_chance: if reuse_args { 50 } else { 0 },
+            power_of_two_chance: if reuse_args { 50 } else { 0 },
         }
     }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -3,8 +3,9 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::sync::{Arc, Mutex};
 
-use libafl::prelude::current_time;
-use libafl::prelude::{format_duration_hms, ClientId, ClientStats, Monitor};
+use libafl_bolts::{current_time, format_duration_hms};
+use libafl::prelude::{ClientStats, Monitor};
+use libafl_bolts::ClientId;
 
 use crate::fuzz_ui::FuzzUI;
 
@@ -24,21 +25,26 @@ impl Monitor for HWFuzzMonitor {
         &mut self.client_stats
     }
 
-    /// the client monitor
+    /// The client monitor
     fn client_stats(&self) -> &[ClientStats] {
         &self.client_stats
     }
 
     /// Time this fuzzing run stated
-    fn start_time(&mut self) -> Duration {
+    fn start_time(&self) -> Duration {
         self.start_time
     }
 
-    fn display(&mut self, _event_msg: String, sender_id: ClientId) {
+    /// Time this fuzzing run stated
+    fn set_start_time(&mut self, time: Duration) {
+        self.start_time = time;
+    }
+
+    fn display(&mut self, _event_msg: &str, sender_id: ClientId) {
         let execs = self.total_execs();
         let execs_per_sec = self.execs_per_sec_pretty();
         {
-            let client = self.client_stats_mut_for(sender_id).clone();
+            let client = self.client_stats_for(sender_id).clone();
 
             let mut ui = self.ui.lock().unwrap();
             let data = ui.data();

--- a/src/mutator.rs
+++ b/src/mutator.rs
@@ -239,7 +239,13 @@ impl RiscVInstructionMutator {
                 }
             }
             Mutation::Remove => {
-                program.remove(valid_pos(rng)?);
+                // Don't remove if it's too small.
+                if program_len >= 4 {
+                    program.remove(valid_pos(rng)?);
+                } else {
+                    // TODO: If we can't remove, we add - does that make sense?
+                    program.insert(add_pos(rng), self.gen_inst(program, rng));
+                }
             }
             Mutation::ReplaceWithNop => {
                 let pos = valid_pos(rng)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,5 @@
 use crate::instructions::{Instruction, InstructionTemplate};
+use libafl_bolts::nonzero;
 
 pub fn parse_instructions(
     input: &Vec<u8>,
@@ -50,7 +51,7 @@ mod tests {
             rng.set_seed(i);
 
             let mut input = Vec::<u8>::new();
-            for _ in 0..rng.below(100) {
+            for _ in 0..rng.below(nonzero!(100)) {
                 input.push((rng.next() % 256) as u8);
             }
 

--- a/src/program_input.rs
+++ b/src/program_input.rs
@@ -1,11 +1,13 @@
 //! The gramatron grammar fuzzer
 use core::hash::{BuildHasher, Hasher};
 use libafl::{
-    prelude::{HasLen, HasTargetBytes, Input, OwnedSlice},
+    prelude::{HasTargetBytes, Input},
     Error,
 };
+use libafl_bolts::HasLen;
+use libafl_bolts::prelude::OwnedSlice;
+use libafl::prelude::CorpusId;
 use std::fmt;
-
 use ahash::RandomState;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -72,7 +74,7 @@ impl<'de> Visitor<'de> for ProgramInputVisitor {
 impl Input for ProgramInput {
     /// Generate a name for this input
     #[must_use]
-    fn generate_name(&self, _idx: usize) -> String {
+    fn generate_name(&self, _id: Option<CorpusId>) -> String {
         let mut hasher = RandomState::with_seeds(0, 0, 0, 0).build_hasher();
         hasher.write(assemble_instructions(&self.insts).as_slice());
         format!("size:{}-hash:{:016x}", self.insts().len(), hasher.finish())


### PR DESCRIPTION
This PR upgrades the fuzzer to LibAFL 0.15.1.

The following need to be checked before this can be merged:

- [ ] **Test cases timeout**: simulations are slow, we need to make sure that forkserver clients don't timeout
- [ ] **Seed loading**: currently we just generate a "NOP" as seed, loading seeds should be trivial though
- [ ] **Update rust version**: projects depending on this repo (namely, PhantomTrails projects) should install `rustup default 1.82` 

**Why?**

It would be nice to be able to dynamically insert/remove the `snippet` mutation when evaluating its effects, instead of having a (compile-time) tuple (see [here](https://github.com/vusec/hw-fuzzing-driver/blob/master/src/mutator.rs#L305)).

For now I implemented this by simply putting the Snippet mutation as last element fo the tuple and [constraining the rng at runtime](https://github.com/vusec/hw-fuzzing-driver/blob/master/src/mutator.rs#L391), which is horrible and makes me want to cry.

It seems like newer LibAFL versions can handle [dynamic mutation lists](https://github.com/AFLplusplus/LibAFL/pull/1893), but I didn't manage to make it work and got bored.

Anyways, since I did the porting effort, we might as well upstream it.
